### PR TITLE
Allow 3.0 version of psr/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Recently having some issues updating libraries, I've tested on my use case and seems to work.
